### PR TITLE
SVN Externals flagged as Modified fix

### DIFF
--- a/SCM_Notifier/SvnXml.cs
+++ b/SCM_Notifier/SvnXml.cs
@@ -60,7 +60,7 @@ namespace pocorall.SCM_Notifier
 
 						if ((elementName == "wc-status") && (attributeName == "item") && (xmlReader.Depth == 4))
 						{
-							if ((attributeValue != "normal") && (attributeValue != "unversioned"))
+							if ((attributeValue != "normal") && (attributeValue != "unversioned") && (attributeValue != "external"))
 								ht ["Modified"] = true;
 
 							skipNextReposStatus = (attributeValue == "conflicted");				// Because it always updated in repository


### PR DESCRIPTION
Changed to handle when SVN externals are used.  It previously was flagging all external directories as Modified.  This change tells modified to not be triggerd when wc-status's item attribute equals external.